### PR TITLE
Develop: Fix crash on startup due to double toolbar [MG]

### DIFF
--- a/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
+++ b/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
@@ -31,7 +31,6 @@ class MainTabbedActivity : AppCompatActivity() {
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         /// source: https://proandroiddev.com/easy-approach-to-navigation-drawer-7fe87d8fd7e7
-        setSupportActionBar(findViewById(R.id.toolbar))
         val sidebar = findViewById<DrawerLayout>(R.id.sidebar)
         val sidebarToggle = ActionBarDrawerToggle(this, sidebar, R.string.open, R.string.close)
         sidebar.addDrawerListener(sidebarToggle)

--- a/app/src/main/res/layout/activity_maintabbed.xml
+++ b/app/src/main/res/layout/activity_maintabbed.xml
@@ -21,15 +21,6 @@
     android:orientation="vertical"
     tools:context=".MainTabbedActivity">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:minHeight="?attr/actionBarSize"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:titleTextColor="@android:color/white"
-        android:background="?attr/colorPrimary">
-    </androidx.appcompat.widget.Toolbar>
-
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabs"
         android:layout_width="match_parent"


### PR DESCRIPTION
- The sidebar code loaded the toolbar (the bar above the tabs)
  when it's already there, making the app crash on startup
- Remove ALSO the toolbar already there above the tab because it
  was completely unused and it just looks plain ugly