### PR TITLE
Feature/OnPoint-012 [DC, GM]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,10 @@ dependencies {
     androidTestImplementation 'androidx.test:core-ktx:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
 
+    //Supressing since it doesn't support older versions of Android
+    //noinspection GradleCompatible
+    implementation "com.android.support:support-compat:28.0.0"
+
 
     implementation 'com.google.android.material:material:1.1.0'
 

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -141,8 +141,8 @@ class AssignmentsListInstrumentedTest {
         onView(withText("SET REMINDER"))
             .check(matches(isDisplayed()))
             .perform(click())
-        onView(withText("OK"))
+        onView(withId(android.R.id.button1)) // OK button, with default Android ID
             .check(matches(isDisplayed()))
-            .perform(click())
+            .perform(click());
     }
 }

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -102,4 +102,24 @@ class AssignmentsListInstrumentedTest {
         onView(withText("Todo")).check(matches(isDisplayed()))
         onView(withText("Assign.")).check(matches(isDisplayed()))
     }
+
+    @Test
+    fun mockNotificationTappingOpensAppInAssignemntTab() {
+        // Mock intent that is fired when tapping on the notification
+        // Does exactly the same stuff as the one implemented inside the app.
+        // Testing the notification behaviour is out of scope: we assume Android works properly.
+        // Espresso additionally does not allow interactions with the notifications, as they
+        // are not within the current View that Espresso can interact with.
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(targetContext, MainTabbedActivity::class.java)
+        //Value 2 for assignmentTab
+        intent.putExtra("tabToOpen", 2);
+        activityTestRule.launchActivity(intent)
+        onView(withText("Main")).check(matches(isDisplayed()))
+        onView(withText("Todo")).check(matches(isDisplayed()))
+        onView(withText("Assign.")).check(matches(isDisplayed()))
+        onView(withId(R.id.assignmentsList)).check(matches(isDisplayed()))
+    }
+
+
 }

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -138,21 +138,11 @@ class AssignmentsListInstrumentedTest {
             .inRoot(isDialog())
             .check(matches(isDisplayed()))
         // There is a button to select the datetime of the reminder
-        onView(withText("Set reminder"))
+        onView(withText("SET REMINDER"))
             .check(matches(isDisplayed()))
             .perform(click())
-        // The date picking dialog appears
-        onView(withText("Set date"))
-            .inRoot(isDialog())
-            .check(matches(isDisplayed()))
-        onView(withText("Set"))
+        onView(withText("OK"))
             .check(matches(isDisplayed()))
             .perform(click())
-        onView(withText("Cancel"))
-            .check(matches(isDisplayed()))
-            .perform(click())
-        // TODO set dialogBuilder.setPositiveButton("Set reminder")
-        // TODO launch a DatePickerDialog
-        // TODO in the DatePickerDialog.onDateSetListener() call buildAndScheduleNotification() and pass the Date to it
     }
 }

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -1,5 +1,8 @@
 package at.tugraz.onpoint
 
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
@@ -8,11 +11,15 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
 import org.hamcrest.CoreMatchers.startsWith
 import org.junit.Rule
 import org.junit.Test
@@ -22,8 +29,9 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class AssignmentsListInstrumentedTest {
     @get:Rule
-     var activityRule: ActivityScenarioRule<MainTabbedActivity> =
+    var activityRule: ActivityScenarioRule<MainTabbedActivity> =
         ActivityScenarioRule(MainTabbedActivity::class.java)
+    var activityTestRule = ActivityTestRule(MainTabbedActivity::class.java)
 
     @Test
     fun activityHasTabList() {
@@ -60,7 +68,12 @@ class AssignmentsListInstrumentedTest {
         onView(withText("Assign.")).perform(ViewActions.click())
         // Click item at position 3
         onView(withId(R.id.assignmentsList))
-            .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(3, click()))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
+                    3,
+                    click()
+                )
+            )
         onView(withId(R.id.fragment_assignment_details_linearlayout))
             .inRoot(isDialog())
             .check(matches(isDisplayed()))
@@ -73,5 +86,20 @@ class AssignmentsListInstrumentedTest {
         onView(withId(R.id.assignmentsListDetailsLinks))
             .check(matches(withText(startsWith("http"))))
             .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun mockNotificationTappingOpensTheApp() {
+        // Mock intent that is fired when tapping on the notification
+        // Does exactly the same stuff as the one implemented inside the app.
+        // Testing the notification behaviour is out of scope: we assume Android works properly.
+        // Espresso additionally does not allow interactions with the notifications, as they
+        // are not within the current View that Espresso can interact with.
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(targetContext, MainTabbedActivity::class.java)
+        activityTestRule.launchActivity(intent)
+        onView(withText("Main")).check(matches(isDisplayed()))
+        onView(withText("Todo")).check(matches(isDisplayed()))
+        onView(withText("Assign.")).check(matches(isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -121,5 +121,38 @@ class AssignmentsListInstrumentedTest {
         onView(withId(R.id.assignmentsList)).check(matches(isDisplayed()))
     }
 
-
+    @Test
+    fun checkDeadlinePickerAppearsWhenClickingOnSetReminder() {
+        launchActivity<MainTabbedActivity>()
+        onView(withText("Assign.")).perform(ViewActions.click())
+        // Click item at position 3
+        onView(withId(R.id.assignmentsList))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
+                    3,
+                    click()
+                )
+            )
+        // The details view of the assignment dialog appears
+        onView(withId(R.id.fragment_assignment_details_linearlayout))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        // There is a button to select the datetime of the reminder
+        onView(withText("Set reminder"))
+            .check(matches(isDisplayed()))
+            .perform(click())
+        // The date picking dialog appears
+        onView(withText("Set date"))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withText("Set"))
+            .check(matches(isDisplayed()))
+            .perform(click())
+        onView(withText("Cancel"))
+            .check(matches(isDisplayed()))
+            .perform(click())
+        // TODO set dialogBuilder.setPositiveButton("Set reminder")
+        // TODO launch a DatePickerDialog
+        // TODO in the DatePickerDialog.onDateSetListener() call buildAndScheduleNotification() and pass the Date to it
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.OnPoint">
-        <activity android:name=".MainTabbedActivity"></activity>
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -17,6 +16,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainTabbedActivity"/>
+        <receiver
+            android:name=".ui.main.ScheduledNotificationReceiver"
+            android:enabled="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/at/tugraz/onpoint/MainActivity.kt
+++ b/app/src/main/java/at/tugraz/onpoint/MainActivity.kt
@@ -25,10 +25,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-
         setContentView(R.layout.activity_main)
-
+        // Redirect to the tabbed activity
         val intent = Intent(this, MainTabbedActivity::class.java)
         startActivity(intent)
     }

--- a/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
+++ b/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
@@ -1,6 +1,9 @@
 package at.tugraz.onpoint
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
 import android.widget.Button
@@ -12,6 +15,9 @@ import androidx.viewpager.widget.ViewPager
 import at.tugraz.onpoint.database.getDbInstance
 import at.tugraz.onpoint.ui.main.SectionsPagerAdapter
 import com.google.android.material.tabs.TabLayout
+
+
+
 
 class MainTabbedActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,6 +35,8 @@ class MainTabbedActivity : AppCompatActivity() {
         tabs.setupWithViewPager(viewPager)
         findViewById<Button>(R.id.switch_language).setOnClickListener { onLanguageSwitch() }
 
+        createNotificationChannel()
+
         ////////////////////////////////////////////////////////////////////////////////////////////
         /// source: https://proandroiddev.com/easy-approach-to-navigation-drawer-7fe87d8fd7e7
         setSupportActionBar(findViewById(R.id.toolbar))
@@ -36,7 +44,6 @@ class MainTabbedActivity : AppCompatActivity() {
         val sidebarToggle = ActionBarDrawerToggle(this, sidebar, R.string.open, R.string.close)
         sidebar.addDrawerListener(sidebarToggle)
         sidebarToggle.syncState()
-
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
@@ -69,11 +76,28 @@ class MainTabbedActivity : AppCompatActivity() {
         val currentLocal: String = sharedPref.getString("locale_to_set", "")!!
         val languagehandler = LanguageHandler()
         if(currentLocal == "en") {
-            languagehandler.setLanguageToSettings(baseContext, "zh");
+            languagehandler.setLanguageToSettings(baseContext, "zh")
         }
         if(currentLocal == "zh") {
             languagehandler.setLanguageToSettings(baseContext, "en")
         }
         recreate()
+    }
+
+    private fun createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = getString(R.string.channel_name)
+            val descriptionText = getString(R.string.channel_description)
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(getString(R.string.CHANNEL_ID), name, importance).apply {
+                description = descriptionText
+            }
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
     }
 }

--- a/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
+++ b/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
@@ -14,6 +14,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.viewpager.widget.ViewPager
 import at.tugraz.onpoint.database.getDbInstance
 import at.tugraz.onpoint.ui.main.SectionsPagerAdapter
+import at.tugraz.onpoint.ui.main.TAB_INDEX_MAIN
 import com.google.android.material.tabs.TabLayout
 
 class MainTabbedActivity : AppCompatActivity() {
@@ -43,6 +44,9 @@ class MainTabbedActivity : AppCompatActivity() {
         sidebar.addDrawerListener(sidebarToggle)
         sidebarToggle.syncState()
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        // Switch to proper tab, if an intent requested it. Otherwise open the default tab.
+        val tabToOpen = intent.getIntExtra("tabToOpen", TAB_INDEX_MAIN)
+        viewPager.currentItem = tabToOpen
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
+++ b/app/src/main/java/at/tugraz/onpoint/MainTabbedActivity.kt
@@ -16,17 +16,18 @@ import at.tugraz.onpoint.database.getDbInstance
 import at.tugraz.onpoint.ui.main.SectionsPagerAdapter
 import com.google.android.material.tabs.TabLayout
 
-
-
-
 class MainTabbedActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Instantiation of the singleton DB once globally so it can be
         // available in all other tabs
         getDbInstance(this)
+        // Preparation of the notification channels used throughout the app
+        createNotificationChannel()
+        // Languages
         val languagehandler = LanguageHandler()
         languagehandler.loadLocale(baseContext)
+        // Display activity and tabs
         setContentView(R.layout.activity_maintabbed)
         val sectionsPagerAdapter = SectionsPagerAdapter(this, supportFragmentManager)
         val viewPager: ViewPager = findViewById(R.id.view_pager)
@@ -34,9 +35,6 @@ class MainTabbedActivity : AppCompatActivity() {
         val tabs: TabLayout = findViewById(R.id.tabs)
         tabs.setupWithViewPager(viewPager)
         findViewById<Button>(R.id.switch_language).setOnClickListener { onLanguageSwitch() }
-
-        createNotificationChannel()
-
         ////////////////////////////////////////////////////////////////////////////////////////////
         /// source: https://proandroiddev.com/easy-approach-to-navigation-drawer-7fe87d8fd7e7
         setSupportActionBar(findViewById(R.id.toolbar))

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentDetailsFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentDetailsFragment.kt
@@ -38,12 +38,22 @@ class AssignmentDetailsFragment(val assignment: Assignment) : DialogFragment(R.l
                 assignment.linksToMultiLineString()
             dialogBuilder.setView(view)
             dialogBuilder.setTitle(assignment.title)
-            dialogBuilder.setNeutralButton(
+            dialogBuilder.setNegativeButton(
                 R.string.assignment_dialog_close_button
             ) { _, _ ->
                 // User cancelled the dialog.
                 // This callback does nothing.
             }
+            dialogBuilder.setPositiveButton(
+                R.string.set_reminder
+            ) { _, _ ->
+                //display the dialog to set time for notification
+                val fragment = AssignmentSetDateDialog(assignment)
+                fragment.show(parentFragmentManager, null)
+
+            }
+
+
             // Create the AlertDialog object and return it
             dialogBuilder.create()
         } ?: throw IllegalStateException("Activity cannot be null")

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentSetDateDialog.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentSetDateDialog.kt
@@ -1,0 +1,41 @@
+package at.tugraz.onpoint.ui.main
+
+import android.app.DatePickerDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.widget.DatePicker
+import androidx.fragment.app.DialogFragment
+import java.lang.reflect.Array.set
+import java.util.*
+
+class AssignmentSetDateDialog(val assignment: Assignment) : DialogFragment(),
+    DatePickerDialog.OnDateSetListener {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        // Use the current date as the default date in the picker
+        val c = Calendar.getInstance(TimeZone.getTimeZone("GMT+01"))
+        val year = c.get(Calendar.YEAR)
+        val month = c.get(Calendar.MONTH)
+        val day = c.get(Calendar.DAY_OF_MONTH)
+
+        // Create a new instance of DatePickerDialog and return it
+        return DatePickerDialog(this.requireContext(), this, year, month, day)
+    }
+
+    override fun onDateSet(view: DatePicker, year: Int, month: Int, day: Int) {
+        var c = Calendar.getInstance(TimeZone.getTimeZone("GMT+01"))
+
+        c.set(year, month, day)
+
+        assignment.buildAndScheduleNotification(this.requireContext(), c)
+    }
+}
+
+
+
+
+
+
+
+
+

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentSetDateDialog.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentSetDateDialog.kt
@@ -23,10 +23,8 @@ class AssignmentSetDateDialog(val assignment: Assignment) : DialogFragment(),
     }
 
     override fun onDateSet(view: DatePicker, year: Int, month: Int, day: Int) {
-        var c = Calendar.getInstance(TimeZone.getTimeZone("GMT+01"))
-
+        val c = Calendar.getInstance(TimeZone.getTimeZone("GMT+01"))
         c.set(year, month, day)
-
         assignment.buildAndScheduleNotification(this.requireContext(), c)
     }
 }

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -3,10 +3,13 @@ package at.tugraz.onpoint.ui.main
 import android.app.AlertDialog
 import android.content.Context
 import android.os.Bundle
+import android.provider.Settings.Global.getString
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -50,6 +53,9 @@ class AssignmentsTabFragment : Fragment() {
                 )
             )
         }
+
+        assignmentsList[0].buildAndFireNotification(this.requireContext(), 0)
+
         // Create the the Recyclerview, make it a linear list (not a grid), assign the list of
         // items to it and provide and adapter constructing each element of the list as a TextView
         val assignmentsRecView: RecyclerView = root.findViewById(R.id.assignmentsList)
@@ -93,6 +99,20 @@ data class Assignment(
             text.append('\n')
         }
         return text.toString()
+    }
+
+    fun buildAndFireNotification(context : Context, id : Int) {
+        val builder = NotificationCompat.Builder(context, context.getString(R.string.CHANNEL_ID))
+            .setSmallIcon(R.drawable.ic_baseline_uni_24)
+            .setContentTitle((context.getString(R.string.assignment_notification_title)))
+            .setContentText(this.title + "\n" + this.deadline.toString())
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        //launch notification
+        with(NotificationManagerCompat.from(context)) {
+            // notificationId is a unique int for each notification that you must define
+            notify(id, builder.build())
+        }
     }
 }
 

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -15,7 +15,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import at.tugraz.onpoint.MainActivity
+import at.tugraz.onpoint.MainTabbedActivity
 import at.tugraz.onpoint.R
 import java.net.URL
 import java.util.*
@@ -113,7 +113,8 @@ data class Assignment(
             .setAutoCancel(true)
         //launch notification
         with(NotificationManagerCompat.from(context)) {
-            // notificationId is a unique int for each notification that you must define
+            // Using the Assignment ID also as notification ID, so each Assignment object
+            // can reference their own notifications, if required.
             notify(id, builder.build())
         }
     }

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -1,21 +1,21 @@
 package at.tugraz.onpoint.ui.main
 
-import android.app.AlertDialog
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
-import android.provider.Settings.Global.getString
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import at.tugraz.onpoint.MainActivity
 import at.tugraz.onpoint.R
 import java.net.URL
 import java.util.*
@@ -43,6 +43,7 @@ class AssignmentsTabFragment : Fragment() {
         for (i in 0..50) {
             assignmentsList.add(
                 Assignment(
+                    i,
                     "Dummy Assignment $i",
                     "Dummy Description $i",
                     Date(),
@@ -53,8 +54,9 @@ class AssignmentsTabFragment : Fragment() {
                 )
             )
         }
-
-        assignmentsList[0].buildAndFireNotification(this.requireContext(), 0)
+        // Firing two dummy notifications on app start, just to try
+        assignmentsList[0].buildAndFireNotification(this.requireContext())
+        assignmentsList[1].buildAndFireNotification(this.requireContext())
 
         // Create the the Recyclerview, make it a linear list (not a grid), assign the list of
         // items to it and provide and adapter constructing each element of the list as a TextView
@@ -87,10 +89,11 @@ class AssignmentsTabFragment : Fragment() {
 }
 
 data class Assignment(
+    val id: Int,
     val title: String,
     val description: String,
     val deadline: Date,
-    val links: ArrayList<URL>
+    val links: ArrayList<URL>,
 ) {
     fun linksToMultiLineString(): String {
         val text: StringBuilder = StringBuilder()
@@ -101,13 +104,13 @@ data class Assignment(
         return text.toString()
     }
 
-    fun buildAndFireNotification(context : Context, id : Int) {
+    fun buildAndFireNotification(context : Context) {
         val builder = NotificationCompat.Builder(context, context.getString(R.string.CHANNEL_ID))
             .setSmallIcon(R.drawable.ic_baseline_uni_24)
-            .setContentTitle((context.getString(R.string.assignment_notification_title)))
-            .setContentText(this.title + "\n" + this.deadline.toString())
+            .setContentTitle(context.getString(R.string.assignment_notification_title))
+            .setContentText(this.title + ": " + this.deadline.toString())
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-
+            .setAutoCancel(true)
         //launch notification
         with(NotificationManagerCompat.from(context)) {
             // notificationId is a unique int for each notification that you must define

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -46,17 +46,13 @@ class AssignmentsTabFragment : Fragment() {
                     "Dummy Assignment $i",
                     "Dummy Description $i",
                     // Dummy deadline:
-                    // - for i==0 the notification is scheduled for now+1m, which makes it appear
-                    //   immediately because we are closer than 24 h to the deadline
-                    // - for i==1 it's scheduled for now+24h+1m, so it should appear in 1m
-                    //   from the creation of this view
+
                     Date(Date().time + (24L * 3600 * 1000 * i) + 60000L),
                     arrayListOf<URL>(
                         URL("https://www.tugraz.at"),
                         URL("https://tc.tugraz.at"),
                     )
                 ),
-                doScheduleNotification = i < 2, // Avoid launching 50 dummy notifications
             )
         }
 
@@ -75,15 +71,12 @@ class AssignmentsTabFragment : Fragment() {
      */
     fun addAssignmentToAssignmentList(
         assignment: Assignment,
-        doScheduleNotification: Boolean = true
     ) {
         latestAssignmentId += 1
         assignment.id = latestAssignmentId
         assignmentsList.add(assignment)
         adapter?.notifyDataSetChanged()
-        if (doScheduleNotification) {
-            assignment.buildAndScheduleNotification(this.requireContext())
-        }
+
     }
 
     companion object {
@@ -125,7 +118,7 @@ data class Assignment(
     }
 
     // Call this function ONLY after the ID is set.
-    fun buildAndScheduleNotification(context: Context) {
+    fun buildAndScheduleNotification(context: Context, reminder_date : Calendar) {
         val intentToLaunchNotification = Intent(context, ScheduledNotificationReceiver::class.java)
         intentToLaunchNotification.putExtra(
             "title",
@@ -141,9 +134,7 @@ data class Assignment(
             PendingIntent.FLAG_UPDATE_CURRENT
         )
         val manager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        // Notification scheduled for 1 day before the deadline
-        val notificationAppearanceInstant = deadline.time - (24 * 3600 * 1000L)
-        manager.set(AlarmManager.RTC_WAKEUP, notificationAppearanceInstant, pending)
+        manager.set(AlarmManager.RTC_WAKEUP, reminder_date.timeInMillis, pending)
     }
 }
 

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -106,12 +106,12 @@ data class Assignment(
 
     fun buildAndFireNotification(context : Context) {
         val intentToOpenTheApp = Intent(context, MainTabbedActivity::class.java)
+        intentToOpenTheApp.putExtra("tabToOpen", TAB_INDEX_ASSIGNMENT)
         val pendingIntentToOpenApp = PendingIntent.getActivity(
             context,
             id,
             intentToOpenTheApp,
             PendingIntent.FLAG_UPDATE_CURRENT)
-
         val builder = NotificationCompat.Builder(context, context.getString(R.string.CHANNEL_ID))
             .setSmallIcon(R.drawable.ic_baseline_uni_24)
             .setContentTitle(context.getString(R.string.assignment_notification_title))

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -105,10 +105,18 @@ data class Assignment(
     }
 
     fun buildAndFireNotification(context : Context) {
+        val intentToOpenTheApp = Intent(context, MainTabbedActivity::class.java)
+        val pendingIntentToOpenApp = PendingIntent.getActivity(
+            context,
+            id,
+            intentToOpenTheApp,
+            PendingIntent.FLAG_UPDATE_CURRENT)
+
         val builder = NotificationCompat.Builder(context, context.getString(R.string.CHANNEL_ID))
             .setSmallIcon(R.drawable.ic_baseline_uni_24)
             .setContentTitle(context.getString(R.string.assignment_notification_title))
             .setContentText(this.title + ": " + this.deadline.toString())
+            .setContentIntent(pendingIntentToOpenApp)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
         //launch notification

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/ScheduledNotification.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/ScheduledNotification.kt
@@ -1,0 +1,36 @@
+package at.tugraz.onpoint.ui.main
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import at.tugraz.onpoint.MainTabbedActivity
+import at.tugraz.onpoint.R
+
+
+class ScheduledNotificationReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val intentToOpenTheApp = Intent(context, MainTabbedActivity::class.java)
+        intentToOpenTheApp.putExtra("tabToOpen", TAB_INDEX_ASSIGNMENT)
+        val pendingIntentToOpenApp = PendingIntent.getActivity(
+            context,
+            intent.getIntExtra("notificationId", 0),
+            intentToOpenTheApp,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        // Build notification based on Intent
+        val notification = NotificationCompat.Builder(context, context.getString(R.string.CHANNEL_ID))
+            .setSmallIcon(R.drawable.ic_baseline_uni_24)
+            .setContentTitle(intent.getStringExtra("title"))
+            .setContentText(intent.getStringExtra("text"))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntentToOpenApp)
+            .build()
+        // Show notification
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.notify(intent.getIntExtra("notificationId", 0), notification)
+    }
+}

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/SectionsPagerAdapter.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/SectionsPagerAdapter.kt
@@ -12,6 +12,10 @@ private val TAB_TITLES = arrayOf(
     R.string.tab_title_assignments,
 )
 
+const val TAB_INDEX_MAIN = 0
+const val TAB_INDEX_TODO = 1
+const val TAB_INDEX_ASSIGNMENT = 2
+
 /**
  * A [FragmentPagerAdapter] that returns a fragment corresponding to
  * one of the sections/tabs/pages.

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -18,4 +18,5 @@
     <string name="assignment_dialog_close_button">关闭</string>
     <string name="channel_description">作业截止通知</string>
     <string name="channel_name">OnPoint渠道</string>
+    <string name="assignment_notification_title" >OnPoint 作业到期 </string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,4 +16,6 @@
     <string name="todolist_heading_done" translatable="false">完毕</string>
     <string name="assignment_dialog_deadline">最后期限: </string>
     <string name="assignment_dialog_close_button">关闭</string>
+    <string name="channel_description">作业截止通知</string>
+    <string name="channel_name">OnPoint渠道</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,4 +19,5 @@
     <string name="channel_description">作业截止通知</string>
     <string name="channel_name">OnPoint渠道</string>
     <string name="assignment_notification_title" >OnPoint 作业到期 </string>
+    <string name="set_reminder">设定提醒 </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,5 +33,6 @@
     <string name="channel_description" >Notifications for Assignment Deadlines</string>
     <string name="CHANNEL_ID" translatable="false">OnPointChannel</string>
     <string name="assignment_notification_title" >OnPoint Assignment Due</string>
+    <string name="set_reminder">Set Reminder</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,5 +32,6 @@
     <string name="channel_name" >OnpointChannel</string>
     <string name="channel_description" >Notifications for Assignment Deadlines</string>
     <string name="CHANNEL_ID" translatable="false">OnPointChannel</string>
+    <string name="assignment_notification_title" >OnPoint Assignment Due</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,8 @@
     <string name="todolist_heading">Active</string>
     <string name="assignment_dialog_deadline">Deadline: </string>
     <string name="assignment_dialog_close_button">Close</string>
+    <string name="channel_name" >OnpointChannel</string>
+    <string name="channel_description" >Notifications for Assignment Deadlines</string>
+    <string name="CHANNEL_ID" translatable="false">OnPointChannel</string>
+
 </resources>


### PR DESCRIPTION
- In the assignment tab, selecting on of the assignments pops up the details dialog (as it did before).
- Said dialog now has an option to set a reminder: just the selection of the dat
- The Assignment class, keeping the details of the assignment (title, descr., deadline etc.) sends an Intent to Android to be notified back in the future (at midnight of the specified date). Setting it in the past (i.e. today or earlier days) triggers the notification immediately.
- Android sends an Intent to the app in the future at the specified time, which creates a notification
- The notification displays the app name, assignment title and deadline
- Tapping on the notification opens the assignments tab
- The notification is scheduled and will appear even if the app is closed or if the phone is powered off in between