### PR TITLE
Feature/OnPoint-023 [SF, GM]

### DIFF
--- a/app/schemas/at.tugraz.onpoint.database.OnPointAppDatabase/6.json
+++ b/app/schemas/at.tugraz.onpoint.database.OnPointAppDatabase/6.json
@@ -1,0 +1,201 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "2111c3e987771951897aa10241255450",
+    "entities": [
+      {
+        "tableName": "Todo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `creation_unix_time` INTEGER NOT NULL, `expiration_unix_time` INTEGER DEFAULT NULL, `is_completed` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creationUnixTime",
+            "columnName": "creation_unix_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expirationUnixTime",
+            "columnName": "expiration_unix_time",
+            "affinity": "INTEGER",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "is_completed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uid"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Assignment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `description` TEXT NOT NULL, `deadline` INTEGER NOT NULL, `links` TEXT NOT NULL, `uid` INTEGER PRIMARY KEY AUTOINCREMENT, `moodle_id` INTEGER, `is_custom` INTEGER NOT NULL, `is_completed` INTEGER NOT NULL, `course_id_from_moodle` INTEGER, `assignment_id_from_moodle` INTEGER, FOREIGN KEY(`moodle_id`) REFERENCES `Moodle`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deadlineUnixTime",
+            "columnName": "deadline",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "links",
+            "columnName": "links",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "moodleId",
+            "columnName": "moodle_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isCustom",
+            "columnName": "is_custom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "is_completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseIdFromMoodle",
+            "columnName": "course_id_from_moodle",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "assignmentIdFromMoodle",
+            "columnName": "assignment_id_from_moodle",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uid"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_Assignment_moodle_id_course_id_from_moodle_assignment_id_from_moodle",
+            "unique": true,
+            "columnNames": [
+              "moodle_id",
+              "course_id_from_moodle",
+              "assignment_id_from_moodle"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Assignment_moodle_id_course_id_from_moodle_assignment_id_from_moodle` ON `${TABLE_NAME}` (`moodle_id`, `course_id_from_moodle`, `assignment_id_from_moodle`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Moodle",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "moodle_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Moodle",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `universityName` TEXT NOT NULL, `userName` TEXT NOT NULL, `password` TEXT NOT NULL, `apiLink` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "universityName",
+            "columnName": "universityName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiLink",
+            "columnName": "apiLink",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uid"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2111c3e987771951897aa10241255450')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -87,7 +87,7 @@ class AssignmentsListInstrumentedTest {
                 Thread.sleep(waitBetweenTriesMillis.toLong())
             }
         }
-        throw AssertionFailedError("Recycler view with $id still empty after wait")
+        throw AssertionFailedError("Recycler view with $id still empty after waiting for the network. It's probably just due to a slow network. Please try running this test again.")
     }
 
     @Test

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -210,7 +210,7 @@ class AssignmentsListInstrumentedTest {
     fun storeNewAssignmentAndRetrieveItFromDb() {
         val links = arrayListOf(URL("https://tc.tugraz.at"), URL("https://www.tugraz.at"))
         val deadline = Date()
-        val uid = assignmentDao.insertOneFromMoodle("my title", "my description", deadline, links)
+        val uid = assignmentDao.insertOneFromMoodle("my title", "my description", deadline, links, 0, 1, 1)
         val assignment: Assignment = assignmentDao.selectOne(uid)
         assert(assignment.uid!!.toLong() == uid)
         assert(assignment.title == "my title")
@@ -231,13 +231,19 @@ class AssignmentsListInstrumentedTest {
             "my title1",
             "my description1",
             deadlineLate,
-            links
+            links,
+            0,
+            1,
+            1
         )
         assignmentDao.insertOneFromMoodle(
             "my title2",
             "my description2",
             deadlineEarly,
-            links
+            links,
+            0,
+            1,
+            2
         )
         val assignmentsList: List<Assignment> = assignmentDao.selectAll()
         assert(assignmentsList.size == 2)
@@ -574,9 +580,9 @@ class AssignmentsListInstrumentedTest {
     @Test
     fun databaseSelectAllSpecific() {
         val assignmentDao = db.getAssignmentDao()
-        assignmentDao.insertOneFromMoodle("Test", "Test", Date(0))
-        assignmentDao.insertOneFromMoodle("Test2", "Test2", Date(2000))
-        assignmentDao.insertOneFromMoodle("Test3", "Test3", Date(1000))
+        assignmentDao.insertOneFromMoodle("Test", "Test", Date(0), null, 0, 1, 1)
+        assignmentDao.insertOneFromMoodle("Test2", "Test2", Date(2000), null, 0, 1, 2)
+        assignmentDao.insertOneFromMoodle("Test3", "Test3", Date(1000), null, 0, 1, 3)
         assignmentDao.insertOneCustom("Test4", "Test4", Date(2000))
         val uid = assignmentDao.insertOneCustom("Test5", "Test5", Date(1000))
         val assignment = assignmentDao.selectOne(uid)

--- a/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
+++ b/app/src/androidTest/java/at/tugraz/onpoint/AssignmentListInstrumentedTest.kt
@@ -403,7 +403,6 @@ class AssignmentsListInstrumentedTest {
             .check(matches(not(withSubstring("<p"))))
 
     }
-    // TODO test that custom assignments are not overwritten/removed by the sync
 
     @Test
     fun checkForCompletedButtonInAssignmentListEntry() {
@@ -539,6 +538,35 @@ class AssignmentsListInstrumentedTest {
             )
         onView(withId(R.id.assignmentsListDetailsCompletedButton))
             .perform(click())
+        onView(withId(R.id.assignmentListCompleted))
+            .check(matches(hasDescendant(withText("Assignment 1"))))
+    }
+
+    @Test
+    fun completedAssignmentsAreNotOverwrittenBySync() {
+        launchActivity<MainTabbedActivity>()
+        onView(withText("Assign.")).perform(click())
+        // Sync the first time
+        onView(withId(R.id.assignment_sync_assignments)).perform(click())
+        waitForRecyclerViewToBeFilled(R.id.assignmentsListNotCompleted)
+        // Mark an assignment from Moodle as completed
+        onView(withId(R.id.assignmentsListNotCompleted))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
+                    1,
+                    click()
+                )
+            )
+        onView(withId(R.id.assignmentsListDetailsCompletedButton)).perform(click())
+        onView(withId(R.id.assignmentListCompleted))
+            .check(matches(hasDescendant(withText("Assignment 1"))))
+        // Sync again
+        onView(withId(R.id.assignment_sync_assignments)).perform(click())
+        waitForRecyclerViewToBeFilled(R.id.assignmentsListNotCompleted)
+        // The completed assignment should NOT be in the not-completed list
+        onView(withId(R.id.assignmentsListNotCompleted))
+            .check(matches(not(hasDescendant(withText("Assignment 1")))))
+        // It's still in the completed list
         onView(withId(R.id.assignmentListCompleted))
             .check(matches(hasDescendant(withText("Assignment 1"))))
     }

--- a/app/src/main/java/at/tugraz/onpoint/database/Database.kt
+++ b/app/src/main/java/at/tugraz/onpoint/database/Database.kt
@@ -180,8 +180,8 @@ interface AssignmentDao {
             assignmentIdFromMoodle)
         }
         catch (e : SQLiteException) {
-            //return uid of already existing entry, currently no updates allowed
-            return selectUidForMoodleIds(moodleId, courseIdFromMoodle, assignmentIdFromMoodle)
+            // Manual UPSERT: on conflict do nothing.
+            return -1
         }
     }
 

--- a/app/src/main/java/at/tugraz/onpoint/database/Database.kt
+++ b/app/src/main/java/at/tugraz/onpoint/database/Database.kt
@@ -151,7 +151,7 @@ interface AssignmentDao {
         description: String,
         deadline: Long,
         links: String,
-        moodleId: Int?,
+        moodleId: Long?,
         isCustom: Boolean,
         isCompleted: Boolean,
         courseIdFromMoodle: Int?,
@@ -163,7 +163,7 @@ interface AssignmentDao {
         description: String,
         deadline: Date,
         links: List<URL>? = null,
-        moodleId: Int,
+        moodleId: Long,
         courseIdFromMoodle: Int,
         assignmentIdFromMoodle: Int,
     ): Long {

--- a/app/src/main/java/at/tugraz/onpoint/database/Database.kt
+++ b/app/src/main/java/at/tugraz/onpoint/database/Database.kt
@@ -126,7 +126,7 @@ interface AssignmentDao {
     @Update
     fun updateOne(assignment: Assignment)
 
-    @Query("INSERT INTO assignment (title, description, deadline, links, moodle_id, is_custom, is_completed) VALUES (:title, :description, :deadline, :links, :moodleId, :isCustom, :isCompleted)")
+    @Query("INSERT INTO assignment (title, description, deadline, links, moodle_id, is_custom, is_completed, course_id_from_moodle, assignment_id_from_moodle) VALUES (:title, :description, :deadline, :links, :moodleId, :isCustom, :isCompleted, :courseIdFromMoodle, :assignmentIdFromMoodle)")
     fun insertOneRaw(
         title: String,
         description: String,
@@ -135,6 +135,8 @@ interface AssignmentDao {
         moodleId: Int?,
         isCustom: Boolean,
         isCompleted: Boolean,
+        courseIdFromMoodle: Int?,
+        assignmentIdFromMoodle: Int?
     ): Long
 
     fun insertOneFromMoodle(
@@ -143,6 +145,8 @@ interface AssignmentDao {
         deadline: Date,
         links: List<URL>? = null,
         moodleId: Int? = null,
+        courseIdFromMoodle: Int,
+        assignmentIdFromMoodle: Int,
     ): Long {
         return insertOneRaw(
             title,
@@ -152,6 +156,8 @@ interface AssignmentDao {
             moodleId,
             isCustom = false,
             isCompleted = false,
+            courseIdFromMoodle,
+            assignmentIdFromMoodle
         )
     }
 
@@ -169,6 +175,8 @@ interface AssignmentDao {
             moodleId = null,
             isCustom = true,
             isCompleted = false,
+            courseIdFromMoodle = null,
+            assignmentIdFromMoodle = null
         )
     }
 
@@ -258,7 +266,13 @@ data class Assignment(
     var isCustom: Boolean = false,
 
     @ColumnInfo(name = "is_completed")
-    var isCompleted: Boolean = false
+    var isCompleted: Boolean = false,
+
+    @ColumnInfo(name = "course_id_from_moodle")
+    var courseIdFromMoodle: Int? = null,
+
+    @ColumnInfo(name = "assignment_id_from_moodle")
+    var assignmentIdFromMoodle: Int? = null
 ) {
     companion object {
         fun convertDeadlineDate(deadline: Date): Long {

--- a/app/src/main/java/at/tugraz/onpoint/moodle/API.kt
+++ b/app/src/main/java/at/tugraz/onpoint/moodle/API.kt
@@ -16,10 +16,12 @@ data class AssignmentResponse(
 )
 
 data class Course(
+    val id: Int,
     val assignments: List<Assignment>
 )
 
 data class Assignment(
+    val id: Int,
     val name: String,
     val intro: String,
     val duedate: Long,

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -181,6 +181,7 @@ class AssignmentsTabFragment : Fragment() {
                                     addAssignmentsFromMoodle(
                                         response.courses,
                                         moodleApi.token,
+                                        account.uid
                                     )
                                 }
                             }
@@ -199,7 +200,7 @@ class AssignmentsTabFragment : Fragment() {
         completedAdapter!!.notifyDataSetChanged()
     }
 
-    private fun addAssignmentsFromMoodle(courses: List<Course>, token: String) {
+    private fun addAssignmentsFromMoodle(courses: List<Course>, token: String, moodleUid: Int) {
         for (course in courses) {
             for (moodleAssignment in course.assignments) {
                 val listOfUrlsStrings: List<String> = moodleAssignment.introattachments.map {
@@ -211,6 +212,9 @@ class AssignmentsTabFragment : Fragment() {
                     description = moodleAssignment.intro,
                     deadline = Date(moodleAssignment.duedate),
                     links = listOfUrls,
+                    moodleLoginId = moodleUid,
+                    courseIdFromMoodle = course.id,
+                    assignmentIdFromMoodle = moodleAssignment.id
                 )
             }
         }
@@ -226,10 +230,12 @@ class AssignmentsTabFragment : Fragment() {
         description: String,
         deadline: Date,
         links: List<URL>? = null,
-        moodleId: Int? = null
+        moodleLoginId: Int,
+        courseIdFromMoodle: Int,
+        assignmentIdFromMoodle: Int
     ) {
         val uid: Long =
-            assignmentDao.insertOneFromMoodle(title, description, deadline, links, moodleId)
+            assignmentDao.insertOneFromMoodle(title, description, deadline, links, moodleLoginId, courseIdFromMoodle, assignmentIdFromMoodle)
         val assignment = assignmentDao.selectOne(uid)
         notCompletedAssignmentsList.add(assignment)
         notCompletedAdapter?.notifyDataSetChanged()

--- a/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
+++ b/app/src/main/java/at/tugraz/onpoint/ui/main/AssignmentsTabFragment.kt
@@ -180,7 +180,7 @@ class AssignmentsTabFragment : Fragment() {
                                     addAssignmentsFromMoodle(
                                         response.courses,
                                         moodleApi.token,
-                                        account.uid
+                                        account.uid.toLong()
                                     )
                                 }
                             }
@@ -193,13 +193,9 @@ class AssignmentsTabFragment : Fragment() {
                 }
             }
         }
-        notCompletedAssignmentsList.addAll(assignmentDao.selectAllNotCompleted())
-        notCompletedAdapter!!.notifyDataSetChanged()
-        completedAssignmentsList.addAll(assignmentDao.selectAllCompleted())
-        completedAdapter!!.notifyDataSetChanged()
     }
 
-    private fun addAssignmentsFromMoodle(courses: List<Course>, token: String, moodleUid: Int) {
+    private fun addAssignmentsFromMoodle(courses: List<Course>, token: String, moodleUid: Long) {
         var newlyAdded = 0
         for (course in courses) {
             for (moodleAssignment in course.assignments) {
@@ -221,6 +217,12 @@ class AssignmentsTabFragment : Fragment() {
                 }
             }
         }
+        notCompletedAssignmentsList.clear()
+        notCompletedAssignmentsList.addAll(assignmentDao.selectAllNotCompleted())
+        notCompletedAdapter!!.notifyDataSetChanged()
+        completedAssignmentsList.clear()
+        completedAssignmentsList.addAll(assignmentDao.selectAllCompleted())
+        completedAdapter!!.notifyDataSetChanged()
         notifyUser("Moodle: added $newlyAdded new assignments")
     }
 


### PR DESCRIPTION
- Fix: now the assignment's completion status is persistent even after re-synchronising
- Fix: asynchronous behaviour of the network request caused some issues with the refreshing of the lists of assignments displayed to the user
- Pre-merged with the release branch
- Improved error message when some test fails due to network issue, so it is clearer that the issue is NOT in the app in case the test goes wrong for the tutors
  ```kotlin
  AssertionFailedError("Recycler view with $id still empty after waiting for the network. It's probably just due to a slow network. Please try running this test again.")
  ```

As always, please **uninstall the app and Gradle-clean** before running the tests.
